### PR TITLE
Enabling flex-grow for placeholders heading.

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -65,6 +65,7 @@ $vue-content-placeholders-spacing: 10px !default;
 .vue-content-placeholders-heading {
   @include vue-content-placeholders-spacing;
   display: flex;
+  flex: 1;
 
   &__img {
     @include vue-content-placeholders;


### PR DESCRIPTION
As an attempted to use vue-content-placeholder inside a Bootstrap 4 `.list-group` component...


```
<ul class="list-group">
    <content-placeholders v-for="n in 8" class="list-group-item" :rounded="true">
        <content-placeholders-heading :img="true"/>
    </content-placeholders>
</ul>
```

...i added `flex: 1;` to the `.vue-content-placeholders-heading` rules, allowing it to expand.