### PR TITLE
Fix color in webkit/safari

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,7 +44,7 @@ $vue-content-placeholders-spacing: 10px !default;
     width: 100vw;
     max-width: 1000px;
     height: 100%;
-    background: linear-gradient(to right, transparent 0%, darken($vue-content-placeholders-secondary-color, 5%) 15%, transparent 30%);
+    background: linear-gradient(to right, rgba(darken($vue-content-placeholders-secondary-color, 5%), 0) 0%, darken($vue-content-placeholders-secondary-color, 5%) 15%, rgba(darken($vue-content-placeholders-secondary-color, 5%), 0) 30%);
     animation-duration: 1.5s;
     animation-fill-mode: forwards;
     animation-iteration-count: infinite;


### PR DESCRIPTION
Webkit handles the `transparent` keyword differently than other browsers resulting in different colors in safari (see #9).